### PR TITLE
Fix Vercel deploy for FastAPI app

### DIFF
--- a/api/outline.py
+++ b/api/outline.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI, Query, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import httpx
 from bs4 import BeautifulSoup
-from mangum import Mangum
 
 app = FastAPI()
 app.add_middleware(
@@ -39,4 +38,4 @@ async def get_country_outline(country: str = Query(...)):
     print("Country processed:", country_name)
     return {"outline": outline}
 
-handler = Mangum(app)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ fastapi
 httpx
 beautifulsoup4
 lxml
-mangum


### PR DESCRIPTION
## Summary
- remove the AWS Mangum adapter
- trim dependency list

## Testing
- `python -m py_compile api/outline.py`


------
https://chatgpt.com/codex/tasks/task_e_6856428057d483218db000e2bb3969d0